### PR TITLE
[COOK-3309] ActiveMQ Service is not starting

### DIFF
--- a/libraries/chef_activemq.rb
+++ b/libraries/chef_activemq.rb
@@ -1,0 +1,50 @@
+#
+# Cookbook Name:: activemq
+# Library:: chef_activemq
+#
+# Author:: Bernardo Gomez Palacio (<bernardo.gomezpalacio@gmail.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+class Chef
+  module ActiveMQ
+    
+    class << self
+
+      # Returns the name of the jar file that contains the ActiveMQ main classes. Since ActiveMQ 5.8.0 the name
+      # of such jar file is "activemq.jar", prior to that it was "run.jar".
+      # 
+      # @param node [Chef::Node] the Chef node
+      # 
+      # @return [String] the name of the ActiveMQ jar file that should be included in the JVM Classpath.
+      def get_amq_jar_name(node)
+
+          version = node['activemq']['version']
+
+          vMj,vMn,vRev = version.split(".").map{ |v|  Integer(v) rescue nil } 
+          runner = case 
+                   when vMj == 5 && vMn >= 8
+                       "activemq.jar"
+                   when vMj >= 6
+                       "activemq.jar"
+                   else
+                       "run.jar"
+                   end
+          runner
+      end
+    end
+  end
+end
+
+

--- a/templates/default/wrapper.conf.erb
+++ b/templates/default/wrapper.conf.erb
@@ -38,7 +38,7 @@ wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperSimpleApp
 # Java Classpath (include wrapper.jar)  Add class path elements as
 #  needed starting from 1
 wrapper.java.classpath.1=%ACTIVEMQ_HOME%/bin/wrapper.jar
-wrapper.java.classpath.2=%ACTIVEMQ_HOME%/bin/activemq.jar
+wrapper.java.classpath.2=%ACTIVEMQ_HOME%/bin/<%= Chef::ActiveMQ.get_amq_jar_name(node) %>
 
 # Java Library Path (location of Wrapper.DLL or libwrapper.so)
 # wrapper.java.library.path.1=%ACTIVEMQ_HOME%/bin/linux-x86-64/


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3309

Running `/etc/init.d/activemq console` failed with the details shown bellow:

```
Running ActiveMQ Broker...
wrapper  | --> Wrapper Started as Console
wrapper  | Launching a JVM...
jvm 1    | Wrapper (Version 3.2.3) http://wrapper.tanukisoftware.org
jvm 1    |   Copyright 1999-2006 Tanuki Software, Inc.  All Rights
Reserved.
jvm 1    |
jvm 1    | WrapperSimpleApp: Unable to locate the class
org.apache.activemq.console.Main: java.lang.ClassNotFoundException:
org.apache.activemq.console.Main
jvm 1    |
jvm 1    | WrapperSimpleApp Usage:
jvm 1    |   java org.tanukisoftware.wrapper.WrapperSimpleApp
{app_class} [app_arguments]
jvm 1    |
jvm 1    | Where:
jvm 1    |   app_class:      The fully qualified class name of the
application to run.
jvm 1    |   app_arguments:  The arguments that would normally be passed
to the
jvm 1    |                   application.
wrapper  | <-- Wrapper Stopped
```

The issue was that the wrapper was not updated to support the latest
ActiveMQ version.

[ticket: NA] : ?
