### PR TITLE
[COOK-4557] activemq cookbook default mirror url is broken

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-default['activemq']['mirror']  = 'http://apache.mirrors.tds.net'
-default['activemq']['version'] = '5.8.0'
+default['activemq']['mirror']  = 'https://repository.apache.org/content/repositories/releases/org/apache'
+default['activemq']['version'] = '5.9.1'
 default['activemq']['home']  = '/opt'
 default['activemq']['wrapper']['max_memory'] = '1024'
 default['activemq']['wrapper']['useDedicatedTaskRunner'] = 'true'


### PR DESCRIPTION
Altered the default mirror url, to a working location that had all versions available. Also set the default version to 5.9.1.
