### PR TITLE
added option to install from package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+default['activemq']['install_type'] = 'tarball'
 default['activemq']['mirror']  = 'https://repository.apache.org/content/repositories/releases/org/apache'
 default['activemq']['version'] = '5.9.1'
 default['activemq']['home']  = '/opt'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,22 +22,33 @@ include_recipe 'java::default'
 tmp = Chef::Config[:file_cache_path]
 version = node['activemq']['version']
 mirror = node['activemq']['mirror']
-activemq_home = "#{node['activemq']['home']}/apache-activemq-#{version}"
+if node['activemq']['install_type'] == 'tarball'
+  activemq_home = "#{node['activemq']['home']}/apache-activemq-#{version}"
+else
+  activemq_home = node['activemq']['home']
+end
 
 directory node['activemq']['home'] do
   recursive true
 end
 
-unless File.exists?("#{activemq_home}/bin/activemq")
-  remote_file "#{tmp}/apache-activemq-#{version}-bin.tar.gz" do
-    source "#{mirror}/activemq/apache-activemq/#{version}/apache-activemq-#{version}-bin.tar.gz"
-    mode   '0644'
+if node['activemq']['install_type'] == 'tarball'
+  unless File.exists?("#{activemq_home}/bin/activemq")
+    remote_file "#{tmp}/apache-activemq-#{version}-bin.tar.gz" do
+      source "#{mirror}/activemq/#{version}/apache-activemq-#{version}-bin.tar.gz"
+      mode   '0644'
+    end
+  
+    execute "tar zxf #{tmp}/apache-activemq-#{version}-bin.tar.gz" do
+      cwd node['activemq']['home']
+    end
   end
-
-  execute "tar zxf #{tmp}/apache-activemq-#{version}-bin.tar.gz" do
-    cwd node['activemq']['home']
+elsif node['activemq']['install_type'] == 'package'
+  package 'activemq' do
+    action :install
   end
 end
+  
 
 file "#{activemq_home}/bin/activemq" do
   owner 'root'


### PR DESCRIPTION
New attribute called node['activemq']['install_type'].  Two are supported: 'package' and 'tarball', the later being the default.  When not overridden, the behavior doesn't change.  When overridden with 'package', a package with the name node['activemq]['package_name'] will be installed.