### PR TITLE
[ISSUE-43] - Removed version lock on java cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,3 +28,25 @@ suites:
     run_list: test::legacy
   - name: resource_based
     run_list: test::default
+  - name: activemq-legacy
+    excludes:
+      - freebsd-11
+      - opensuse-leap-42
+    run_list: test::legacy
+    verifier:
+      inspec_tests:
+        - name: activemq-legacy
+          path: test/integration/activemq-legacy
+      attrs:
+        - test/integration/attributes/activemq.yml
+  - name: activemq-resource
+    excludes:
+      - freebsd-11
+      - opensuse-leap-42
+    run_list: test::default
+    verifier:
+      inspec_tests:
+        - name: activemq-resource
+          path: test/integration/activemq-resource
+      attrs:
+        - test/integration/attributes/activemq.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the activemq cookbook.
 
+## Unreleased
+
+- Bumped ActiveMQ version to 5.14.5
+- Removed version lock on java cookbook
+- Added 2 new test suites that could be used to replace the existing ones
+
 ## 4.1.0 (2017-05-06)
 
 - Require Chef 12.7+ to workaround action_class bug

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The activemq_install resource installs an instance of the Apache ActiveMQ binary
 #### Properties
 
 * `instance_name`, String
-* `version`, String. The version to install. Default: '5.12.0'
+* `version`, String. The version to install. Default: '5.14.5'
 * `home`, String. The top level directory to install software. Default: '/opt'
 * `install_path`, String. The full level path to install software.
 * `tarball_base_path`, String. The base path to the location containing the binary package of ActiveMQ. Default: 'http://archive.apache. org/dist/activemq/'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 
 default['activemq']['mirror']  = 'https://repository.apache.org/content/repositories/releases/org/apache'
-default['activemq']['version'] = '5.14.4'
+default['activemq']['version'] = '5.14.5'
 default['activemq']['home'] = '/opt'
 default['activemq']['wrapper']['max_memory'] = '1024'
 default['activemq']['wrapper']['useDedicatedTaskRunner'] = 'true'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe 'activemq::default', 'Installs Apache ActiveMQ and sets up the service us
   supports os
 end
 
-depends 'java', '~> 1.13'
+depends 'java'
 
 source_url 'https://github.com/chef-cookbooks/activemq'
 issues_url 'https://github.com/chef-cookbooks/activemq/issues'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,5 +1,5 @@
 property :instance_name, String, name_property: true
-property :version, String, default: '5.14.4'
+property :version, String, default: '5.14.5'
 property :install_path, String, default: lazy { |r| "/opt/activemq_#{r.instance_name}_#{r.version.tr('.', '_')}/" }
 property :tarball_base_path, String, default: 'http://archive.apache.org/dist/activemq/'
 property :checksum_base_path, String, default: 'http://archive.apache.org/dist/activemq/'

--- a/test/integration/activemq-legacy/controls/activemq_legacy_spec.rb
+++ b/test/integration/activemq-legacy/controls/activemq_legacy_spec.rb
@@ -1,0 +1,124 @@
+activemq_version = attribute('activemq_version',
+                             default: '5.14.5',
+                             description: 'Which version of ActiveMQ is to be installed'
+                            )
+activemq_install_dir = attribute('activemq_install_directory',
+                                 default: "/opt/apache-activemq-#{activemq_version}",
+                                 description: 'Get the path where ActiveMQ should be installed'
+                                )
+activemq_service_enabled = attribute('activemq_service_enabled',
+                                     default: true,
+                                     description: 'Enable and start ActiveMQ servers when true'
+                                    )
+
+arch = os[:arch] == 'x86_64' ? 'x86-64' : 'x86-32'
+
+control 'check-tar-installation' do
+  impact 1.0
+  title 'Verify that the tar package is installed'
+  desc 'Verify tar is installed so ActiveMQ can be installed'
+
+  describe package('tar') do
+    it { should be_installed }
+  end
+end
+
+control 'check-activemq-binary-perms' do
+  impact 1.0
+  title 'Verify that the ActiveMQ binary permissions are correct'
+  desc 'Verify ActiveMQ binary has the correct permissions'
+
+  describe file("#{activemq_install_dir}/bin/activemq") do
+    it { should exist }
+    it { should be_file }
+    its('mode') { should cmp 0o755 }
+    its('group') { should eq 'root' }
+    its('owner') { should eq 'root' }
+  end
+end
+
+control 'check-init.d-link' do
+  impact 1.0
+  title 'Verify the run level start/stop link got installed'
+  desc 'Verify that start-stop link got installed in /etc/init.d'
+
+  describe file('/etc/init.d/activemq') do
+    it { should exist }
+    it { should be_symlink }
+    its('link_path') { should eq "#{activemq_install_dir}/bin/linux-#{arch}/activemq" }
+  end
+end
+
+control 'activemq-service-status' do
+  impact 1.0
+  title 'Verify the ActiveMQ service is set when flag is true'
+  desc 'Verify the ActiveMQ service is running and enabled when true'
+
+  if activemq_service_enabled
+    describe service('activemq') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  else
+    describe service('activemq') do
+      it { should_not be_installed }
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
+  end
+end
+
+control 'check-wrapper-conf-link' do
+  impact 1.0
+  title 'Verify link from bin/linux to bin/linux-arch'
+  desc 'Verify link to bin/lunx to bin/linux-arch exists for wrapper.conf'
+
+  describe file("#{activemq_install_dir}/bin/linux") do
+    it { should exist }
+    it { should be_symlink }
+    its('link_path') { should eq "#{activemq_install_dir}/bin/linux-#{arch}" }
+  end
+end
+
+control 'check-pid-file-link' do
+  impact 1.0
+  title 'Verify link from pid file to /var/run/activemq.pid'
+  desc 'Verify link from pid file to /var/run/activemq.pid exists'
+
+  describe file('/var/run/activemq.pid') do
+    it { should exist }
+    it { should be_symlink }
+    its('link_path') { should eq "#{activemq_install_dir}/bin/linux-#{arch}/ActiveMQ.pid" }
+  end
+end
+
+control 'check-for-running-activemq' do
+  impact 1.0
+  title 'Verify that the ActiveMQ process is running'
+  desc 'Verify that there is a running process for ActiveMQ'
+
+  describe command('ps ax | grep activem[q]') do
+    its('exit_status') { should eq 0 }
+  end
+end
+
+control 'check-for-producer-messages' do
+  impact 1.0
+  title 'Verify that the ActiveMQ producer messages is 1000'
+  desc 'Verify that ActiveMQ produces messages'
+
+  describe command("/opt/apache-activemq-#{activemq_version}/bin/activemq producer") do
+    its('stdout') { should match(/Produced: 1000 messages/) }
+  end
+end
+
+control 'check-for-consumer-messages' do
+  impact 1.0
+  title 'Verify that the ActiveMQ consumer messages is 1000'
+  desc 'Verify that ActiveMQ produces messages'
+
+  describe command("/opt/apache-activemq-#{activemq_version}/bin/activemq consumer") do
+    its('stdout') { should match(/Consumed: 1000 messages/) }
+  end
+end

--- a/test/integration/activemq-legacy/inspec.yml
+++ b/test/integration/activemq-legacy/inspec.yml
@@ -1,0 +1,9 @@
+name: activemq-legacy
+title: ActiveMQ Inspec installation tests using activemq::default
+license: Public Domain
+copyright: none
+summary: Verify ActiveMQ is installed via legacy recipe
+version: 0.0.1
+
+supports:
+  - os-family: linux

--- a/test/integration/activemq-resource/controls/activemq_resource_spec.rb
+++ b/test/integration/activemq-resource/controls/activemq_resource_spec.rb
@@ -1,0 +1,77 @@
+activemq_version = attribute('activemq_version',
+                             default: '5.14.5',
+                             description: 'Which version of ActiveMQ is to be installed'
+                            )
+activemq_instance_name = attribute('activemq_instance_name',
+                                   default: 'main_queue',
+                                   description: 'Instance being created, which is also the user/group names'
+                                  )
+activemq_group_name = attribute('activemq_group_name',
+                                default: "activemq_#{activemq_instance_name}",
+                                description: 'Get the group name to use for permissions of the instance'
+                               )
+activemq_user_name = attribute('activemq_user_name',
+                                default: "activemq_#{activemq_instance_name}",
+                                description: 'Get the name name to use for permissions of the instance'
+                              )
+activemq_install_dir = attribute('activemq_install_directory',
+                                 default: "/opt/activemq_#{activemq_instance_name}_#{activemq_version.tr('.', '_')}",
+                                 description: 'Get the path where ActiveAQ should be installed'
+                                )
+
+control 'check-tar-installation' do
+  impact 1.0
+  title 'Verify that the tar package is installed'
+  desc 'Verify tar is installed so ActiveAQ can be installed'
+
+  describe package('tar') do
+    it { should be_installed }
+  end
+end
+
+control 'check-group-name' do
+  impact 1.0
+  title 'Verify that the group is created'
+  desc 'Verify that /etc/group contains an entry for the instance name'
+
+  describe group(activemq_group_name) do
+    it { should exist }
+  end
+end
+
+control 'check-user-name' do
+  impact 1.0
+  title 'Verify that the user is created'
+  desc 'Verify that /etc/passwd contains an entry for the instance name'
+
+  describe group(activemq_user_name) do
+    it { should exist }
+  end
+end
+
+control 'check-install-directory' do
+  impact 1.0
+  title 'Verify the install directory has been created'
+  desc 'Verify the existence of the ActiveAQ installation directory'
+
+  describe directory(activemq_install_dir) do
+    it { should exist }
+    it { should be_directory }
+    its('path') { should eq activemq_install_dir }
+    its('mode') { should cmp 0o750 }
+    its('group') { should eq activemq_group_name }
+    its('owner') { should eq activemq_user_name }
+  end
+end
+
+control 'check-install-link' do
+  impact 1.0
+  title 'Verify the link to the install directory has been created'
+  desc 'Verify the existence of the link to the installation directory'
+
+  describe file("/opt/activemq_#{activemq_instance_name}") do
+    it { should exist }
+    it { should be_symlink }
+    its('link_path') { should eq activemq_install_dir }
+  end
+end

--- a/test/integration/activemq-resource/inspec.yml
+++ b/test/integration/activemq-resource/inspec.yml
@@ -1,0 +1,9 @@
+name: activemq-resource
+title: ActiveMQ Inspec tests for the activemq_install resource
+license: Public Domain
+copyright: none
+summary: Verify ActiveMQ is installed via resource
+version: 0.0.1
+
+supports:
+  - os-family: linux

--- a/test/integration/attributes/activemq.yml
+++ b/test/integration/attributes/activemq.yml
@@ -1,0 +1,1 @@
+activemq_version: 5.14.5

--- a/test/integration/default/activemq_spec.rb
+++ b/test/integration/default/activemq_spec.rb
@@ -2,10 +2,10 @@ describe command('ps ax | grep activem[q]') do
   its('exit_status') { should eq 0 }
 end
 
-describe command('/opt/apache-activemq-5.14.4/bin/activemq producer') do
+describe command('/opt/apache-activemq-5.14.5/bin/activemq producer') do
   its('stdout') { should match(/Produced: 1000 messages/) }
 end
 
-describe command('/opt/apache-activemq-5.14.4/bin/activemq consumer') do
+describe command('/opt/apache-activemq-5.14.5/bin/activemq consumer') do
   its('stdout') { should match(/Consumed: 1000 messages/) }
 end


### PR DESCRIPTION
### Description

Removed version lock on the java cookbook
Bumped ActiveMQ to 5.14.5
Added additional test suites

### Issues Resolved

#43 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
